### PR TITLE
Contracts helper

### DIFF
--- a/contracts/AbstractRandomnessReceiver.sol
+++ b/contracts/AbstractRandomnessReceiver.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {IRandomnessReceiver} from "./IRandomnessReceiver.sol";
+
+abstract contract AbstractRandomnessReceiver {
+    address randomnessRequester;
+
+    error NotAuthorizedRandomnessProvider();
+
+    modifier onlyRandomnessProvider(){
+        if (msg.sender != randomnessRequester) revert NotAuthorizedRandomnessProvider();
+        _;
+    }
+
+    constructor(address _randomnessRequester) public {
+        randomnessRequester = _randomnessRequester;
+    }
+}

--- a/contracts/AbstractRandomnessReceiver.sol
+++ b/contracts/AbstractRandomnessReceiver.sol
@@ -13,7 +13,7 @@ abstract contract AbstractRandomnessReceiver {
         _;
     }
 
-    constructor(address _randomnessRequester) public {
+    constructor(address _randomnessRequester) {
         randomnessRequester = _randomnessRequester;
     }
 }

--- a/contracts/IRandomnessProvider.sol
+++ b/contracts/IRandomnessProvider.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.24;
 
 import "./TypesLib.sol";
 
-interface IRandomnessRequester {
+interface IRandomnessProvider {
     /**
      * @notice Requests the generation of a random value for a specified blockchain height.
      * @dev Initiates a randomness request.

--- a/contracts/IRandomnessReceiver.sol
+++ b/contracts/IRandomnessReceiver.sol
@@ -6,8 +6,8 @@ interface IRandomnessReceiver {
      * @notice Receives a random value associated with a specific request.
      * @dev This function is called to provide the randomness generated for a given request ID.
      * It is intended to be called by a trusted source that provides randomness.
-     * @param requestID The unique identifier of the randomness request.
+     * @param requestId The unique identifier of the randomness request.
      * @param randomness The generated random value, provided as a `bytes32` type.
      */
-    function receiveRandomness(uint256 requestID, bytes32 randomness) external;
+    function receiveRandomness(uint256 requestId, bytes32 randomness) external;
 }

--- a/contracts/IRandomnessRequester.sol
+++ b/contracts/IRandomnessRequester.sol
@@ -7,10 +7,10 @@ interface IRandomnessRequester {
     /**
      * @notice Requests the generation of a random value for a specified blockchain height.
      * @dev Initiates a randomness request.
-     * The generated randomness will be associated with the returned `requestID`.
-     * @return requestID The unique identifier assigned to this randomness request.
+     * The generated randomness will be associated with the returned `requestId`.
+     * @return requestId The unique identifier assigned to this randomness request.
      */
-    function requestRandomness() external returns (uint256 requestID);
+    function requestRandomness() external returns (uint256 requestId);
 
     /**
      * @notice Retrieves a specific request by its ID.

--- a/contracts/TypesLib.sol
+++ b/contracts/TypesLib.sol
@@ -5,7 +5,7 @@ library TypesLib {
 
     // RandomnessRequest stores details needed to verify the signature
     struct RandomnessRequest {
-        uint256 requestID;
+        uint256 requestId;
         address callback;
     }
 

--- a/contracts/helper/MockRandomnessRequester.sol
+++ b/contracts/helper/MockRandomnessRequester.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "../IRandomnessReceiver.sol";
+import "../IRandomnessRequester.sol";
+
+contract MockRandomnessRequester is IRandomnessRequester {
+    mapping(uint256 => address) requestIdToReceiver;    
+    uint256 public lastRequestId;
+    uint256[] requests;
+    mapping(address => uint256[]) public receiverToRequestIds;
+
+    function requestRandomness() external returns (uint256) {
+        lastRequestId++;
+        requestIdToReceiver[lastRequestId] = msg.sender;
+        requests.push(lastRequestId);
+        return lastRequestId;
+    }
+
+    function getRequest(uint256 requestId) external view returns (TypesLib.RandomnessRequest memory){
+        return TypesLib.RandomnessRequest(requestId, requestIdToReceiver[requestId]);
+    }
+
+    function getAllRequests() external view returns (TypesLib.RandomnessRequest[] memory){
+        TypesLib.RandomnessRequest[] memory allRequests = new TypesLib.RandomnessRequest[](15);
+        for(uint i; i<15; i++){
+            address callBack = requestIdToReceiver[requests[i]];
+            allRequests[i] = TypesLib.RandomnessRequest(requests[i], callBack);
+        }
+        return allRequests;
+    }
+
+    function messageFrom(TypesLib.RandomnessRequest memory r) external pure returns (bytes memory){
+        return bytes("");
+    }
+
+    function answerRequest(uint256 requestId, bytes32 randomness) external {
+        address callback = requestIdToReceiver[requestId];
+        IRandomnessReceiver receiver = IRandomnessReceiver(callback);
+        receiver.receiveRandomness(requestId, randomness);
+    }
+}

--- a/contracts/helper/MockRandomnessRequester.sol
+++ b/contracts/helper/MockRandomnessRequester.sol
@@ -5,6 +5,21 @@ import "../IRandomnessReceiver.sol";
 import "../IRandomnessProvider.sol";
 
 contract MockRandomnessRequester is IRandomnessProvider {
+    // the DST is used to separate randomness being used as signatures for other things
+    string public constant DST = "randomness:0.0.1:bn254";
+    // while the signature is verifiable, this is done elsewhere so ensure only the signer contract can write back here
+    bytes32 public constant SIGNER_ROLE = keccak256("SIGNER_ROLE");
+    
+    // Request stores details needed to verify the signature
+    struct Request {
+        uint256 nonce;
+        address callback;
+    }
+
+    event RandomnessRequested(uint256 indexed requestID, uint256 nonce, address requester);
+    event RandomnessCallbackSuccess(uint256 indexed requestID, bytes32 randomness, bytes signature);
+    event RandomnessCallbackFailed(uint256 indexed requestID, bytes32 randomness, bytes signature);
+
     mapping(uint256 => address) requestIdToReceiver;    
     uint256 public lastRequestId;
     uint256[] requests;
@@ -22,8 +37,8 @@ contract MockRandomnessRequester is IRandomnessProvider {
     }
 
     function getAllRequests() external view returns (TypesLib.RandomnessRequest[] memory){
-        TypesLib.RandomnessRequest[] memory allRequests = new TypesLib.RandomnessRequest[](15);
-        for(uint i; i<15; i++){
+        TypesLib.RandomnessRequest[] memory allRequests = new TypesLib.RandomnessRequest[](lastRequestId);
+        for(uint i; i<lastRequestId; i++){
             address callBack = requestIdToReceiver[requests[i]];
             allRequests[i] = TypesLib.RandomnessRequest(requests[i], callBack);
         }
@@ -31,9 +46,11 @@ contract MockRandomnessRequester is IRandomnessProvider {
     }
 
     function messageFrom(TypesLib.RandomnessRequest memory r) external pure returns (bytes memory){
-        return bytes("");
+        bytes memory m = abi.encode(DST, r.requestId);
+        return abi.encodePacked(keccak256(m));
     }
 
+    // Function to manually provide the contract with the desired randomness
     function answerRequest(uint256 requestId, bytes32 randomness) external {
         address callback = requestIdToReceiver[requestId];
         IRandomnessReceiver receiver = IRandomnessReceiver(callback);

--- a/contracts/helper/MockRandomnessRequester.sol
+++ b/contracts/helper/MockRandomnessRequester.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.13;
 
 import "../IRandomnessReceiver.sol";
-import "../IRandomnessRequester.sol";
+import "../IRandomnessProvider.sol";
 
-contract MockRandomnessRequester is IRandomnessRequester {
+contract MockRandomnessRequester is IRandomnessProvider {
     mapping(uint256 => address) requestIdToReceiver;    
     uint256 public lastRequestId;
     uint256[] requests;


### PR DESCRIPTION
Change all occurrences of "requestID" to "requestId" in the solidity code.
Add the helper contract: MockRandomnessRequester.sol, still a draft: `messageFrom` and `getAllRequests` aren't correctly implemented